### PR TITLE
Remove CFLAG neon from aarch64, and various other fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,12 @@
 #The C compiler to use 
 CC = g++
 #C flags
+uname_p := $(shell uname -p)
+ifeq ($(uname_p),aarch64)
+CFLAGS = -Wall
+else
 CFLAGS = -Wall -mfpu=neon
+endif
 #Preprocessor flags like include paths
 CPPFLAGS+=	-I. 
 #Add libraries to this, e.g. -lm for the math library
@@ -25,4 +30,4 @@ $(BINARY) : $(SRCS) $(DEPS)
 
 .PHONY: clean    
 clean :
-	-rm $(BINARY) *.o  *.out 2> /dev/null
+	-rm -f $(BINARY) *.o  *.out 2> /dev/null

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Rewriting code written for SSE to work on Neon is very time consuming.  This is 
 #include "SSE2NEON.h"
 ```
 
-- On Linux compile your code with the following gcc/g++ flag:   
+- On Linux ARM platform (exclude AArch64) compile your code with the following gcc/g++ flag:   
  ```
  -mfpu=neon 
  ```

--- a/SSE2NEON.h
+++ b/SSE2NEON.h
@@ -142,6 +142,7 @@
 
 typedef float32x4_t __m128;
 typedef int32x4_t __m128i;
+typedef float64x2_t __m128d;
 
 
 // ******************************************
@@ -1680,11 +1681,6 @@ FORCE_INLINE void _mm_clflush(void const*p)
 	// no corollary for Neon?
 }
 
-#if defined(__GNUC__) || defined(__clang__)
-#	pragma pop_macro("ALIGN_STRUCT")
-#	pragma pop_macro("FORCE_INLINE")
-#endif
-
 FORCE_INLINE __m128d  _mm_set_pd (double e1, double e0) {
      float64_t __attribute__((aligned(16))) data[2] = {e0,e1};
      return  vld1q_f64(data);
@@ -1702,7 +1698,7 @@ FORCE_INLINE uint64_t _mm_popcnt_u64(uint64_t x) {
     count16x4_val = vpaddl_u8(count8x8_val);
     count32x2_val = vpaddl_u16(count16x4_val);
     count64x1_val = vpaddl_u32(count32x2_val);
-    vst1_u64(count, count64x1_val);
+    vst1_u64(&count, count64x1_val);
     return count;
 }
 
@@ -1776,7 +1772,9 @@ FORCE_INLINE int _mm_popcnt_u32(uint32_t a)
 
 FORCE_INLINE __m128i _mm_sll_epi64(__m128i a, __m128i b)
 {
-    int64_t value = vget_low_s64(vreinterpretq_s64_m128i(b));
+    int64_t value;
+    int64x1_t value_64x1 = vget_low_s64(vreinterpretq_s64_m128i(b));
+    vst1_s64(&value, value_64x1);
 
     if (value <= 0) {
         return a;
@@ -1812,4 +1810,9 @@ FORCE_INLINE __m128i _mm_cmpeq_epi64 (__m128i a, __m128i b)
 	ret; \
 })
 
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#	pragma pop_macro("ALIGN_STRUCT")
+#	pragma pop_macro("FORCE_INLINE")
 #endif


### PR DESCRIPTION
-mfpu is not a valid option on aarch64 (arm64), so remove this flag if aarch64 detected

Ref:
https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html
https://lists.linaro.org/pipermail/linaro-toolchain/2016-July/005815.html
https://stackoverflow.com/a/29891469/2882845

Also, various other fixes for the latest patch.